### PR TITLE
[Python] Add (and use) a robot_loader function

### DIFF
--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -89,10 +89,7 @@ def loadANYmal(withArm=None):
 
 
 def loadTalosArm():
-    URDF_FILENAME = "talos_left_arm.urdf"
-    SRDF_FILENAME = "talos.srdf"
-
-    return robot_loader('talos_data', URDF_FILENAME, SRDF_FILENAME)
+    return robot_loader('talos_data', "talos_left_arm.urdf", "talos.srdf")
 
 
 def loadTalos(legs=False):
@@ -168,55 +165,39 @@ def loadTalosLegs():
 
 
 def loadHyQ():
-    URDF_FILENAME = "hyq_no_sensors.urdf"
-    SRDF_FILENAME = "hyq.srdf"
-
-    return robot_loader('hyq_description', URDF_FILENAME, SRDF_FILENAME, ref_posture="standing", free_flyer=True)
+    return robot_loader('hyq_description', "hyq_no_sensors.urdf", "hyq.srdf", ref_posture="standing", free_flyer=True)
 
 
 def loadSolo(solo=True):
-    if solo:
-        URDF_FILENAME = "solo.urdf"
-    else:
-        URDF_FILENAME = "solo12.urdf"
-    SRDF_FILENAME = "solo.srdf"
-
-    return robot_loader('solo_description', URDF_FILENAME, SRDF_FILENAME, ref_posture="standing", free_flyer=True)
+    return robot_loader('solo_description',
+                        "solo.urdf" if solo else "solo12.urdf",
+                        "solo.srdf",
+                        ref_posture="standing",
+                        free_flyer=True)
 
 
 def loadKinova():
-    URDF_FILENAME = "kinova.urdf"
-    SRDF_FILENAME = "kinova.srdf"
-
-    return robot_loader('kinova_description', URDF_FILENAME, SRDF_FILENAME, ref_posture="arm_up")
+    return robot_loader('kinova_description', "kinova.urdf", "kinova.srdf", ref_posture="arm_up")
 
 
-def loadTiago():
-    URDF_FILENAME = "tiago.urdf"
-    # SRDF_FILENAME = "tiago.srdf"
-    return robot_loader('tiago_description', URDF_FILENAME)
+def loadTiago(hand=True):
+    return robot_loader('tiago_description', "tiago.urdf" if hand else "tiago_no_hand.urdf")
 
 
 def loadTiagoNoHand():
-    URDF_FILENAME = "tiago_no_hand.urdf"
-    # SRDF_FILENAME = "tiago.srdf"
-    return robot_loader('tiago_description', URDF_FILENAME)
+    warnings.warn("`loadTiagoNoHand()` is deprecated. Please use `loadTiago(hand=False)`", DeprecationWarning, 2)
+    return loadTiago(hand=False)
 
 
 def loadICub(reduced=True):
-    if reduced:
-        URDF_FILENAME = "icub_reduced.urdf"
-    else:
-        URDF_FILENAME = "icub.urdf"
-    SRDF_FILENAME = "icub.srdf"
-
-    return robot_loader('icub_description', URDF_FILENAME, SRDF_FILENAME, free_flyer=True)
+    return robot_loader('icub_description',
+                        "icub_reduced.urdf" if reduced else "icub.urdf",
+                        "icub.srdf",
+                        free_flyer=True)
 
 
 def loadPanda():
-    URDF_FILENAME = "panda.urdf"
-
-    return robot_loader('panda_description', URDF_FILENAME, urdf_subpath='urdf')
+    return robot_loader('panda_description', "panda.urdf", urdf_subpath='urdf')
 
 
 def loadUR(robot=5, limited=False, gripper=False):
@@ -231,24 +212,16 @@ def loadUR(robot=5, limited=False, gripper=False):
 
 
 def loadHector():
-    URDF_FILENAME = "quadrotor_base.urdf"
-
-    return robot_loader('hector_description', URDF_FILENAME, free_flyer=True)
+    return robot_loader('hector_description', "quadroto_base.urdf", free_flyer=True)
 
 
 def loadDoublePendulum():
-    URDF_FILENAME = "double_pendulum.urdf"
-
-    return robot_loader('double_pendulum_description', URDF_FILENAME, urdf_subpath='urdf')
+    return robot_loader('double_pendulum_description', "double_pendulum.urdf", urdf_subpath='urdf')
 
 
 def loadRomeo():
-    URDF_FILENAME = "romeo.urdf"
-
-    return robot_loader('romeo_description', URDF_FILENAME, urdf_subpath='urdf', free_flyer=True)
+    return robot_loader('romeo_description', "romeo.urdf", urdf_subpath='urdf', free_flyer=True)
 
 
 def loadIris():
-    URDF_FILENAME = "iris_simple.urdf"
-
-    return robot_loader('iris_description', URDF_FILENAME, free_flyer=True)
+    return robot_loader('iris_description', "iris_simple.urdf", free_flyer=True)

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -2,10 +2,10 @@ import sys
 from os.path import dirname, exists, join
 
 import numpy as np
-import pinocchio
+import pinocchio as pin
 from pinocchio.robot_wrapper import RobotWrapper
 
-pinocchio.switchToNumpyArray()
+pin.switchToNumpyArray()
 
 
 def getModelPath(subpath, printmsg=False):
@@ -33,10 +33,10 @@ def getVisualPath(modelPath):
 
 def readParamsFromSrdf(model, SRDF_PATH, verbose=False, has_rotor_parameters=True, referencePose='half_sitting'):
     if has_rotor_parameters:
-        pinocchio.loadRotorParameters(model, SRDF_PATH, verbose)
+        pin.loadRotorParameters(model, SRDF_PATH, verbose)
     model.armature = np.multiply(model.rotorInertia.flat, np.square(model.rotorGearRatio.flat))
-    pinocchio.loadReferenceConfigurations(model, SRDF_PATH, verbose)
-    q0 = pinocchio.neutral(model)
+    pin.loadReferenceConfigurations(model, SRDF_PATH, verbose)
+    q0 = pin.neutral(model)
     if referencePose is not None:
         q0 = model.referenceConfigurations[referencePose].copy()
     return q0
@@ -64,8 +64,7 @@ def loadANYmal(withArm=None):
     SRDF_SUBPATH = "/anymal_b_simple_description/srdf/" + SRDF_FILENAME
     modelPath = getModelPath(URDF_SUBPATH)
     # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)],
-                                       pinocchio.JointModelFreeFlyer())
+    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
     # Load SRDF file
     robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False, referencePose=REF_POSTURE)
     # Add the free-flyer joint limits
@@ -94,8 +93,7 @@ def loadTalos():
     URDF_SUBPATH = "/talos_data/robots/" + URDF_FILENAME
     modelPath = getModelPath(URDF_SUBPATH)
     # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)],
-                                       pinocchio.JointModelFreeFlyer())
+    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
     # Load SRDF file
     robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False)
     assert ((robot.model.armature[:6] == 0.).all())
@@ -114,10 +112,10 @@ def loadTalosLegs():
 
     legMaxId = 14
     m1 = robot.model
-    m2 = pinocchio.Model()
+    m2 = pin.Model()
     for j, M, name, parent, Y in zip(m1.joints, m1.jointPlacements, m1.names, m1.parents, m1.inertias):
         if j.id < legMaxId:
-            jid = m2.addJoint(parent, getattr(pinocchio, j.shortname())(), M, name)
+            jid = m2.addJoint(parent, getattr(pin, j.shortname())(), M, name)
             upperPos = m2.upperPositionLimit
             lowerPos = m2.lowerPositionLimit
             effort = m2.effortLimit
@@ -128,7 +126,7 @@ def loadTalosLegs():
             m2.lowerPositionLimit = lowerPos
             m2.effortLimit = effort
             assert (jid == j.id)
-            m2.appendBodyToJoint(jid, Y, pinocchio.SE3.Identity())
+            m2.appendBodyToJoint(jid, Y, pin.SE3.Identity())
 
     upperPos = m2.upperPositionLimit
     upperPos[:7] = 1
@@ -145,7 +143,7 @@ def loadTalosLegs():
         if f.parent < legMaxId:
             m2.addFrame(f)
 
-    g2 = pinocchio.GeometryModel()
+    g2 = pin.GeometryModel()
     for g in robot.visual_model.geometryObjects:
         if g.parentJoint < 14:
             g2.addGeometryObject(g)
@@ -154,7 +152,7 @@ def loadTalosLegs():
     robot.data = m2.createData()
     robot.visual_model = g2
     # robot.q0=q2
-    robot.visual_data = pinocchio.GeometryData(g2)
+    robot.visual_data = pin.GeometryData(g2)
 
     # Load SRDF file
     robot.q0 = robot.q0[:robot.model.nq]
@@ -173,8 +171,7 @@ def loadHyQ():
     URDF_SUBPATH = "/hyq_description/robots/" + URDF_FILENAME
     modelPath = getModelPath(URDF_SUBPATH)
     # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)],
-                                       pinocchio.JointModelFreeFlyer())
+    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
     # Load SRDF file
     robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False, "standing")
     # Add the free-flyer joint limits
@@ -192,8 +189,7 @@ def loadSolo(solo=True):
     URDF_SUBPATH = "/solo_description/robots/" + URDF_FILENAME
     modelPath = getModelPath(URDF_SUBPATH)
     # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)],
-                                       pinocchio.JointModelFreeFlyer())
+    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
     # Load SRDF file
     robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False, "standing")
     # Add the free-flyer joint limits
@@ -250,8 +246,7 @@ def loadICub(reduced=True):
     URDF_SUBPATH = "/icub_description/robots/" + URDF_FILENAME
     modelPath = getModelPath(URDF_SUBPATH)
     # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)],
-                                       pinocchio.JointModelFreeFlyer())
+    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
     # Load SRDF file
     robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False)
     # Add the free-flyer joint limits
@@ -285,8 +280,7 @@ def loadHector():
     URDF_FILENAME = "quadrotor_base.urdf"
     URDF_SUBPATH = "/hector_description/robots/" + URDF_FILENAME
     modelPath = getModelPath(URDF_SUBPATH)
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)],
-                                       pinocchio.JointModelFreeFlyer())
+    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
     return robot
 
 
@@ -302,14 +296,12 @@ def loadRomeo():
     URDF_FILENAME = "romeo.urdf"
     URDF_SUBPATH = "/romeo_description/urdf/" + URDF_FILENAME
     modelPath = getModelPath(URDF_SUBPATH)
-    return RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)],
-                                      pinocchio.JointModelFreeFlyer())
+    return RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
 
 
 def loadIris():
     URDF_FILENAME = "iris_simple.urdf"
     URDF_SUBPATH = "/iris_description/robots/" + URDF_FILENAME
     modelPath = getModelPath(URDF_SUBPATH)
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)],
-                                       pinocchio.JointModelFreeFlyer())
+    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
     return robot

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -3,6 +3,7 @@ import warnings
 from os.path import dirname, exists, join
 
 import numpy as np
+
 import pinocchio as pin
 from pinocchio.robot_wrapper import RobotWrapper
 
@@ -92,7 +93,7 @@ def loadTalos(legs=False, arm=False):
     URDF_FILENAME = "talos_left_arm.urdf" if arm else "talos_reduced.urdf"
     SRDF_FILENAME = "talos.srdf"
 
-    robot = robot_loader('talos_data', URDF_FILENAME, SRDF_FILENAME, free_flyer=True)
+    robot = robot_loader('talos_data', URDF_FILENAME, SRDF_FILENAME, free_flyer=not arm)
 
     assert (robot.model.armature[:6] == 0.).all()
 

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from os.path import dirname, exists, join
 
 import numpy as np
@@ -27,10 +28,6 @@ def getModelPath(subpath, printmsg=False):
     raise IOError('%s not found' % subpath)
 
 
-def getVisualPath(modelPath):
-    return join(modelPath, '../..')
-
-
 def readParamsFromSrdf(model, SRDF_PATH, verbose=False, has_rotor_parameters=True, referencePose='half_sitting'):
     if has_rotor_parameters:
         pin.loadRotorParameters(model, SRDF_PATH, verbose)
@@ -51,6 +48,29 @@ def addFreeFlyerJointLimits(model):
     model.lowerPositionLimit = lb
 
 
+def robot_loader(urdf_filename,
+                 urdf_subpath,
+                 srdf_filename=None,
+                 srdf_subpath=None,
+                 verbose=False,
+                 has_rotor_parameters=False,
+                 ref_posture='half_sitting',
+                 free_flyer=False):
+    """Helper function to load a robot."""
+    urdf_path = join(urdf_subpath, urdf_filename)
+    model_path = getModelPath(urdf_path)
+    robot = RobotWrapper.BuildFromURDF(join(model_path, urdf_path), [join(model_path, '../..')],
+                                       pin.JointModelFreeFlyer() if free_flyer else None)
+
+    if srdf_filename is not None:
+        robot.q0 = readParamsFromSrdf(robot.model, join(model_path, srdf_subpath, srdf_filename), verbose,
+                                      has_rotor_parameters, ref_posture)
+    if free_flyer:
+        addFreeFlyerJointLimits(robot.model)
+
+    return robot
+
+
 def loadANYmal(withArm=None):
     if withArm is None:
         URDF_FILENAME = "anymal.urdf"
@@ -60,123 +80,113 @@ def loadANYmal(withArm=None):
         URDF_FILENAME = "anymal-kinova.urdf"
         SRDF_FILENAME = "anymal-kinova.srdf"
         REF_POSTURE = "standing_with_arm_up"
-    URDF_SUBPATH = "/anymal_b_simple_description/robots/" + URDF_FILENAME
-    SRDF_SUBPATH = "/anymal_b_simple_description/srdf/" + SRDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
-    # Load SRDF file
-    robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False, referencePose=REF_POSTURE)
-    # Add the free-flyer joint limits
-    addFreeFlyerJointLimits(robot.model)
-    return robot
+
+    URDF_SUBPATH = "anymal_b_simple_description/robots"
+    SRDF_SUBPATH = "anymal_b_simple_description/srdf"
+
+    return robot_loader(URDF_FILENAME,
+                        URDF_SUBPATH,
+                        SRDF_FILENAME,
+                        SRDF_SUBPATH,
+                        ref_posture=REF_POSTURE,
+                        free_flyer=True)
 
 
 def loadTalosArm():
     URDF_FILENAME = "talos_left_arm.urdf"
-    URDF_SUBPATH = "/talos_data/robots/" + URDF_FILENAME
     SRDF_FILENAME = "talos.srdf"
-    SRDF_SUBPATH = "/talos_data/srdf/" + SRDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)])
+    URDF_SUBPATH = "talos_data/robots"
+    SRDF_SUBPATH = "talos_data/srdf"
 
-    # Load SRDF file
-    robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False)
-    return robot
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH)
 
 
-def loadTalos():
+def loadTalos(legs=False):
     URDF_FILENAME = "talos_reduced.urdf"
     SRDF_FILENAME = "talos.srdf"
-    SRDF_SUBPATH = "/talos_data/srdf/" + SRDF_FILENAME
-    URDF_SUBPATH = "/talos_data/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
-    # Load SRDF file
-    robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False)
-    assert ((robot.model.armature[:6] == 0.).all())
-    # Add the free-flyer joint limits
-    addFreeFlyerJointLimits(robot.model)
+    SRDF_SUBPATH = "talos_data/srdf"
+    URDF_SUBPATH = "talos_data/robots"
+
+    robot = robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH, free_flyer=True)
+
+    assert (robot.model.armature[:6] == 0.).all()
+
+    if legs:
+        legMaxId = 14
+        m1 = robot.model
+        m2 = pin.Model()
+        for j, M, name, parent, Y in zip(m1.joints, m1.jointPlacements, m1.names, m1.parents, m1.inertias):
+            if j.id < legMaxId:
+                jid = m2.addJoint(parent, getattr(pin, j.shortname())(), M, name)
+                upperPos = m2.upperPositionLimit
+                lowerPos = m2.lowerPositionLimit
+                effort = m2.effortLimit
+                upperPos[m2.joints[jid].idx_q:m2.joints[jid].idx_q + j.nq] = m1.upperPositionLimit[j.idx_q:j.idx_q +
+                                                                                                   j.nq]
+                lowerPos[m2.joints[jid].idx_q:m2.joints[jid].idx_q + j.nq] = m1.lowerPositionLimit[j.idx_q:j.idx_q +
+                                                                                                   j.nq]
+                effort[m2.joints[jid].idx_v:m2.joints[jid].idx_v + j.nv] = m1.effortLimit[j.idx_v:j.idx_v + j.nv]
+                m2.upperPositionLimit = upperPos
+                m2.lowerPositionLimit = lowerPos
+                m2.effortLimit = effort
+                assert (jid == j.id)
+                m2.appendBodyToJoint(jid, Y, pin.SE3.Identity())
+
+        upperPos = m2.upperPositionLimit
+        upperPos[:7] = 1
+        m2.upperPositionLimit = upperPos
+        lowerPos = m2.lowerPositionLimit
+        lowerPos[:7] = -1
+        m2.lowerPositionLimit = lowerPos
+        effort = m2.effortLimit
+        effort[:6] = np.inf
+        m2.effortLimit = effort
+
+        # q2 = robot.q0[:19]
+        for f in m1.frames:
+            if f.parent < legMaxId:
+                m2.addFrame(f)
+
+        g2 = pin.GeometryModel()
+        for g in robot.visual_model.geometryObjects:
+            if g.parentJoint < 14:
+                g2.addGeometryObject(g)
+
+        robot.model = m2
+        robot.data = m2.createData()
+        robot.visual_model = g2
+        # robot.q0=q2
+        robot.visual_data = pin.GeometryData(g2)
+
+        # Load SRDF file
+        robot.q0 = robot.q0[:robot.model.nq]
+        model_path = getModelPath(join(URDF_SUBPATH, URDF_FILENAME))
+        robot.q0 = readParamsFromSrdf(robot.model, join(model_path, SRDF_SUBPATH, SRDF_FILENAME), False)
+
+        assert ((m2.armature[:6] == 0.).all())
+        # Add the free-flyer joint limits to the new model
+        addFreeFlyerJointLimits(robot.model)
+
     return robot
 
 
 def loadTalosLegs():
-    robot = loadTalos()
-    URDF_FILENAME = "talos_reduced.urdf"
-    SRDF_FILENAME = "talos.srdf"
-    SRDF_SUBPATH = "/talos_data/srdf/" + SRDF_FILENAME
-    URDF_SUBPATH = "/talos_data/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-
-    legMaxId = 14
-    m1 = robot.model
-    m2 = pin.Model()
-    for j, M, name, parent, Y in zip(m1.joints, m1.jointPlacements, m1.names, m1.parents, m1.inertias):
-        if j.id < legMaxId:
-            jid = m2.addJoint(parent, getattr(pin, j.shortname())(), M, name)
-            upperPos = m2.upperPositionLimit
-            lowerPos = m2.lowerPositionLimit
-            effort = m2.effortLimit
-            upperPos[m2.joints[jid].idx_q:m2.joints[jid].idx_q + j.nq] = m1.upperPositionLimit[j.idx_q:j.idx_q + j.nq]
-            lowerPos[m2.joints[jid].idx_q:m2.joints[jid].idx_q + j.nq] = m1.lowerPositionLimit[j.idx_q:j.idx_q + j.nq]
-            effort[m2.joints[jid].idx_v:m2.joints[jid].idx_v + j.nv] = m1.effortLimit[j.idx_v:j.idx_v + j.nv]
-            m2.upperPositionLimit = upperPos
-            m2.lowerPositionLimit = lowerPos
-            m2.effortLimit = effort
-            assert (jid == j.id)
-            m2.appendBodyToJoint(jid, Y, pin.SE3.Identity())
-
-    upperPos = m2.upperPositionLimit
-    upperPos[:7] = 1
-    m2.upperPositionLimit = upperPos
-    lowerPos = m2.lowerPositionLimit
-    lowerPos[:7] = -1
-    m2.lowerPositionLimit = lowerPos
-    effort = m2.effortLimit
-    effort[:6] = np.inf
-    m2.effortLimit = effort
-
-    # q2 = robot.q0[:19]
-    for f in m1.frames:
-        if f.parent < legMaxId:
-            m2.addFrame(f)
-
-    g2 = pin.GeometryModel()
-    for g in robot.visual_model.geometryObjects:
-        if g.parentJoint < 14:
-            g2.addGeometryObject(g)
-
-    robot.model = m2
-    robot.data = m2.createData()
-    robot.visual_model = g2
-    # robot.q0=q2
-    robot.visual_data = pin.GeometryData(g2)
-
-    # Load SRDF file
-    robot.q0 = robot.q0[:robot.model.nq]
-    robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False)
-
-    assert ((m2.armature[:6] == 0.).all())
-    # Add the free-flyer joint limits
-    addFreeFlyerJointLimits(robot.model)
-    return robot
+    warnings.warn("`loadTalosLegs()` is deprecated. Please use `loadTalos(legs=True)`", DeprecationWarning, 2)
+    return loadTalos(legs=True)
 
 
 def loadHyQ():
     URDF_FILENAME = "hyq_no_sensors.urdf"
     SRDF_FILENAME = "hyq.srdf"
-    SRDF_SUBPATH = "/hyq_description/srdf/" + SRDF_FILENAME
-    URDF_SUBPATH = "/hyq_description/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
-    # Load SRDF file
-    robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False, "standing")
-    # Add the free-flyer joint limits
-    addFreeFlyerJointLimits(robot.model)
-    return robot
+    SRDF_SUBPATH = "hyq_description/srdf"
+    URDF_SUBPATH = "hyq_description/robots"
+
+    return robot_loader(URDF_FILENAME,
+                        URDF_SUBPATH,
+                        SRDF_FILENAME,
+                        SRDF_SUBPATH,
+                        ref_posture="standing",
+                        free_flyer=True)
 
 
 def loadSolo(solo=True):
@@ -185,55 +195,40 @@ def loadSolo(solo=True):
     else:
         URDF_FILENAME = "solo12.urdf"
     SRDF_FILENAME = "solo.srdf"
-    SRDF_SUBPATH = "/solo_description/srdf/" + SRDF_FILENAME
-    URDF_SUBPATH = "/solo_description/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
-    # Load SRDF file
-    robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False, "standing")
-    # Add the free-flyer joint limits
-    addFreeFlyerJointLimits(robot.model)
-    return robot
+    SRDF_SUBPATH = "solo_description/srdf"
+    URDF_SUBPATH = "solo_description/robots"
+
+    return robot_loader(URDF_FILENAME,
+                        URDF_SUBPATH,
+                        SRDF_FILENAME,
+                        SRDF_SUBPATH,
+                        ref_posture="standing",
+                        free_flyer=True)
 
 
 def loadKinova():
     URDF_FILENAME = "kinova.urdf"
     SRDF_FILENAME = "kinova.srdf"
-    SRDF_SUBPATH = "/kinova_description/srdf/" + SRDF_FILENAME
-    URDF_SUBPATH = "/kinova_description/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)])
-    # Load SRDF file
-    robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False, "arm_up")
-    return robot
+    SRDF_SUBPATH = "kinova_description/srdf"
+    URDF_SUBPATH = "kinova_description/robots"
+
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH, ref_posture="arm_up")
 
 
 def loadTiago():
     URDF_FILENAME = "tiago.urdf"
-    #    SRDF_FILENAME = "tiago.srdf"
-    #    SRDF_SUBPATH = "/tiago_description/srdf/" + SRDF_FILENAME
-    URDF_SUBPATH = "/tiago_description/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)])
-    # Load SRDF file
-    #    robot.q0 = readParamsFromSrdf(robot.model, modelPath+SRDF_SUBPATH, False)
-    return robot
+    # SRDF_FILENAME = "tiago.srdf"
+    # SRDF_SUBPATH = "tiago_description/srdf"
+    URDF_SUBPATH = "tiago_description/robots"
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH)
 
 
 def loadTiagoNoHand():
     URDF_FILENAME = "tiago_no_hand.urdf"
-    #    SRDF_FILENAME = "tiago.srdf"
-    #    SRDF_SUBPATH = "/tiago_description/srdf/" + SRDF_FILENAME
-    URDF_SUBPATH = "/tiago_description/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)])
-    # Load SRDF file
-    #    robot.q0 = readParamsFromSrdf(robot.model, modelPath+SRDF_SUBPATH, False)
-    return robot
+    # SRDF_FILENAME = "tiago.srdf"
+    # SRDF_SUBPATH = "tiago_description/srdf"
+    URDF_SUBPATH = "tiago_description/robots"
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH)
 
 
 def loadICub(reduced=True):
@@ -242,66 +237,56 @@ def loadICub(reduced=True):
     else:
         URDF_FILENAME = "icub.urdf"
     SRDF_FILENAME = "icub.srdf"
-    SRDF_SUBPATH = "/icub_description/srdf/" + SRDF_FILENAME
-    URDF_SUBPATH = "/icub_description/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    # Load URDF file
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
-    # Load SRDF file
-    robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False)
-    # Add the free-flyer joint limits
-    addFreeFlyerJointLimits(robot.model)
-    return robot
+    SRDF_SUBPATH = "icub_description/srdf"
+    URDF_SUBPATH = "icub_description/robots"
+
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH, free_flyer=True)
 
 
 def loadPanda():
     URDF_FILENAME = "panda.urdf"
-    URDF_SUBPATH = "/panda_description/urdf/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)])
+    URDF_SUBPATH = "panda_description/urdf"
 
-    return robot
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH)
 
 
 def loadUR(robot=5, limited=False, gripper=False):
     assert (not (gripper and (robot == 10 or limited)))
     URDF_FILENAME = "ur%i%s_%s.urdf" % (robot, "_joint_limited" if limited else '', 'gripper' if gripper else 'robot')
-    URDF_SUBPATH = "/ur_description/urdf/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)])
+    URDF_SUBPATH = "ur_description/urdf"
     if robot == 5 or robot == 3 and gripper:
         SRDF_FILENAME = "ur%i%s.srdf" % (robot, '_gripper' if gripper else '')
-        SRDF_SUBPATH = "/ur_description/srdf/" + SRDF_FILENAME
-        robot.q0 = readParamsFromSrdf(robot.model, modelPath + SRDF_SUBPATH, False, False, None)
-    return robot
+        SRDF_SUBPATH = "ur_description/srdf"
+    else:
+        SRDF_FILENAME = None
+        SRDF_SUBPATH = None
+
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH, ref_posture=None)
 
 
 def loadHector():
     URDF_FILENAME = "quadrotor_base.urdf"
-    URDF_SUBPATH = "/hector_description/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
-    return robot
+    URDF_SUBPATH = "hector_description/robots"
+
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
 
 
 def loadDoublePendulum():
     URDF_FILENAME = "double_pendulum.urdf"
-    URDF_SUBPATH = "/double_pendulum_description/urdf/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)])
-    return robot
+    URDF_SUBPATH = "double_pendulum_description/urdf"
+
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH)
 
 
 def loadRomeo():
     URDF_FILENAME = "romeo.urdf"
-    URDF_SUBPATH = "/romeo_description/urdf/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    return RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
+    URDF_SUBPATH = "romeo_description/urdf"
+
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
 
 
 def loadIris():
     URDF_FILENAME = "iris_simple.urdf"
-    URDF_SUBPATH = "/iris_description/robots/" + URDF_FILENAME
-    modelPath = getModelPath(URDF_SUBPATH)
-    robot = RobotWrapper.BuildFromURDF(modelPath + URDF_SUBPATH, [getVisualPath(modelPath)], pin.JointModelFreeFlyer())
-    return robot
+    URDF_SUBPATH = "iris_description/robots"
+
+    return robot_loader(URDF_FILENAME, URDF_SUBPATH, free_flyer=True)

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -121,7 +121,7 @@ def loadTalos(legs=False):
                 m2.upperPositionLimit = upperPos
                 m2.lowerPositionLimit = lowerPos
                 m2.effortLimit = effort
-                assert (jid == j.id)
+                assert jid == j.id
                 m2.appendBodyToJoint(jid, Y, pin.SE3.Identity())
 
         upperPos = m2.upperPositionLimit
@@ -155,7 +155,7 @@ def loadTalos(legs=False):
         model_path = getModelPath(join('talos_data/robots', URDF_FILENAME))
         robot.q0 = readParamsFromSrdf(robot.model, join(model_path, 'talos_data/srdf', SRDF_FILENAME), False)
 
-        assert ((m2.armature[:6] == 0.).all())
+        assert (m2.armature[:6] == 0.).all()
         # Add the free-flyer joint limits to the new model
         addFreeFlyerJointLimits(robot.model)
 
@@ -220,7 +220,7 @@ def loadPanda():
 
 
 def loadUR(robot=5, limited=False, gripper=False):
-    assert (not (gripper and (robot == 10 or limited)))
+    assert not (gripper and (robot == 10 or limited))
     URDF_FILENAME = "ur%i%s_%s.urdf" % (robot, "_joint_limited" if limited else '', 'gripper' if gripper else 'robot')
     if robot == 5 or robot == 3 and gripper:
         SRDF_FILENAME = "ur%i%s.srdf" % (robot, '_gripper' if gripper else '')

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -50,14 +50,14 @@ def addFreeFlyerJointLimits(model):
 
 def robot_loader(path,
                  urdf_filename,
-                 urdf_subpath=None,
                  srdf_filename=None,
+                 urdf_subpath='robots',
                  verbose=False,
                  has_rotor_parameters=False,
                  ref_posture='half_sitting',
                  free_flyer=False):
     """Helper function to load a robot."""
-    urdf_path = join(urdf_subpath, urdf_filename)
+    urdf_path = join(path, urdf_subpath, urdf_filename)
     model_path = getModelPath(urdf_path)
     robot = RobotWrapper.BuildFromURDF(join(model_path, urdf_path), [join(model_path, '../..')],
                                        pin.JointModelFreeFlyer() if free_flyer else None)
@@ -81,11 +81,8 @@ def loadANYmal(withArm=None):
         SRDF_FILENAME = "anymal-kinova.srdf"
         REF_POSTURE = "standing_with_arm_up"
 
-    URDF_SUBPATH = "anymal_b_simple_description/robots"
-
     return robot_loader('anymal_b_simple_description',
                         URDF_FILENAME,
-                        URDF_SUBPATH,
                         SRDF_FILENAME,
                         ref_posture=REF_POSTURE,
                         free_flyer=True)
@@ -94,17 +91,15 @@ def loadANYmal(withArm=None):
 def loadTalosArm():
     URDF_FILENAME = "talos_left_arm.urdf"
     SRDF_FILENAME = "talos.srdf"
-    URDF_SUBPATH = "talos_data/robots"
 
-    return robot_loader('talos_data', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME)
+    return robot_loader('talos_data', URDF_FILENAME, SRDF_FILENAME)
 
 
 def loadTalos(legs=False):
     URDF_FILENAME = "talos_reduced.urdf"
     SRDF_FILENAME = "talos.srdf"
-    URDF_SUBPATH = "talos_data/robots"
 
-    robot = robot_loader('talos_data', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, free_flyer=True)
+    robot = robot_loader('talos_data', URDF_FILENAME, SRDF_FILENAME, free_flyer=True)
 
     assert (robot.model.armature[:6] == 0.).all()
 
@@ -157,7 +152,7 @@ def loadTalos(legs=False):
 
         # Load SRDF file
         robot.q0 = robot.q0[:robot.model.nq]
-        model_path = getModelPath(join(URDF_SUBPATH, URDF_FILENAME))
+        model_path = getModelPath(join('talos_data/robots', URDF_FILENAME))
         robot.q0 = readParamsFromSrdf(robot.model, join(model_path, 'talos_data/srdf', SRDF_FILENAME), False)
 
         assert ((m2.armature[:6] == 0.).all())
@@ -175,14 +170,8 @@ def loadTalosLegs():
 def loadHyQ():
     URDF_FILENAME = "hyq_no_sensors.urdf"
     SRDF_FILENAME = "hyq.srdf"
-    URDF_SUBPATH = "hyq_description/robots"
 
-    return robot_loader('hyq_description',
-                        URDF_FILENAME,
-                        URDF_SUBPATH,
-                        SRDF_FILENAME,
-                        ref_posture="standing",
-                        free_flyer=True)
+    return robot_loader('hyq_description', URDF_FILENAME, SRDF_FILENAME, ref_posture="standing", free_flyer=True)
 
 
 def loadSolo(solo=True):
@@ -191,36 +180,27 @@ def loadSolo(solo=True):
     else:
         URDF_FILENAME = "solo12.urdf"
     SRDF_FILENAME = "solo.srdf"
-    URDF_SUBPATH = "solo_description/robots"
 
-    return robot_loader('solo_description',
-                        URDF_FILENAME,
-                        URDF_SUBPATH,
-                        SRDF_FILENAME,
-                        ref_posture="standing",
-                        free_flyer=True)
+    return robot_loader('solo_description', URDF_FILENAME, SRDF_FILENAME, ref_posture="standing", free_flyer=True)
 
 
 def loadKinova():
     URDF_FILENAME = "kinova.urdf"
     SRDF_FILENAME = "kinova.srdf"
-    URDF_SUBPATH = "kinova_description/robots"
 
-    return robot_loader('kinova_description', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, ref_posture="arm_up")
+    return robot_loader('kinova_description', URDF_FILENAME, SRDF_FILENAME, ref_posture="arm_up")
 
 
 def loadTiago():
     URDF_FILENAME = "tiago.urdf"
     # SRDF_FILENAME = "tiago.srdf"
-    URDF_SUBPATH = "tiago_description/robots"
-    return robot_loader('tiago_description', URDF_FILENAME, URDF_SUBPATH)
+    return robot_loader('tiago_description', URDF_FILENAME)
 
 
 def loadTiagoNoHand():
     URDF_FILENAME = "tiago_no_hand.urdf"
     # SRDF_FILENAME = "tiago.srdf"
-    URDF_SUBPATH = "tiago_description/robots"
-    return robot_loader('tiago_description', URDF_FILENAME, URDF_SUBPATH)
+    return robot_loader('tiago_description', URDF_FILENAME)
 
 
 def loadICub(reduced=True):
@@ -229,53 +209,46 @@ def loadICub(reduced=True):
     else:
         URDF_FILENAME = "icub.urdf"
     SRDF_FILENAME = "icub.srdf"
-    URDF_SUBPATH = "icub_description/robots"
 
-    return robot_loader('icub_description', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, free_flyer=True)
+    return robot_loader('icub_description', URDF_FILENAME, SRDF_FILENAME, free_flyer=True)
 
 
 def loadPanda():
     URDF_FILENAME = "panda.urdf"
-    URDF_SUBPATH = "panda_description/urdf"
 
-    return robot_loader('panda_description', URDF_FILENAME, URDF_SUBPATH)
+    return robot_loader('panda_description', URDF_FILENAME, urdf_subpath='urdf')
 
 
 def loadUR(robot=5, limited=False, gripper=False):
     assert (not (gripper and (robot == 10 or limited)))
     URDF_FILENAME = "ur%i%s_%s.urdf" % (robot, "_joint_limited" if limited else '', 'gripper' if gripper else 'robot')
-    URDF_SUBPATH = "ur_description/urdf"
     if robot == 5 or robot == 3 and gripper:
         SRDF_FILENAME = "ur%i%s.srdf" % (robot, '_gripper' if gripper else '')
     else:
         SRDF_FILENAME = None
 
-    return robot_loader('ur_description', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, ref_posture=None)
+    return robot_loader('ur_description', URDF_FILENAME, SRDF_FILENAME, urdf_subpath='urdf', ref_posture=None)
 
 
 def loadHector():
     URDF_FILENAME = "quadrotor_base.urdf"
-    URDF_SUBPATH = "hector_description/robots"
 
-    return robot_loader('hector_description', URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
+    return robot_loader('hector_description', URDF_FILENAME, free_flyer=True)
 
 
 def loadDoublePendulum():
     URDF_FILENAME = "double_pendulum.urdf"
-    URDF_SUBPATH = "double_pendulum_description/urdf"
 
-    return robot_loader('double_pendulum_description', URDF_FILENAME, URDF_SUBPATH)
+    return robot_loader('double_pendulum_description', URDF_FILENAME, urdf_subpath='urdf')
 
 
 def loadRomeo():
     URDF_FILENAME = "romeo.urdf"
-    URDF_SUBPATH = "romeo_description/urdf"
 
-    return robot_loader('romeo_description', URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
+    return robot_loader('romeo_description', URDF_FILENAME, urdf_subpath='urdf', free_flyer=True)
 
 
 def loadIris():
     URDF_FILENAME = "iris_simple.urdf"
-    URDF_SUBPATH = "iris_description/robots"
 
-    return robot_loader('iris_description', URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
+    return robot_loader('iris_description', URDF_FILENAME, free_flyer=True)

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -88,12 +88,8 @@ def loadANYmal(withArm=None):
                         free_flyer=True)
 
 
-def loadTalosArm():
-    return robot_loader('talos_data', "talos_left_arm.urdf", "talos.srdf")
-
-
-def loadTalos(legs=False):
-    URDF_FILENAME = "talos_reduced.urdf"
+def loadTalos(legs=False, arm=False):
+    URDF_FILENAME = "talos_left_arm.urdf" if arm else "talos_reduced.urdf"
     SRDF_FILENAME = "talos.srdf"
 
     robot = robot_loader('talos_data', URDF_FILENAME, SRDF_FILENAME, free_flyer=True)
@@ -162,6 +158,11 @@ def loadTalos(legs=False):
 def loadTalosLegs():
     warnings.warn("`loadTalosLegs()` is deprecated. Please use `loadTalos(legs=True)`", DeprecationWarning, 2)
     return loadTalos(legs=True)
+
+
+def loadTalosArm():
+    warnings.warn("`loadTalosArm()` is deprecated. Please use `loadTalos(arm=True)`", DeprecationWarning, 2)
+    return loadTalos(arm=True)
 
 
 def loadHyQ():

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -48,10 +48,10 @@ def addFreeFlyerJointLimits(model):
     model.lowerPositionLimit = lb
 
 
-def robot_loader(urdf_filename,
-                 urdf_subpath,
+def robot_loader(path,
+                 urdf_filename,
+                 urdf_subpath=None,
                  srdf_filename=None,
-                 srdf_subpath=None,
                  verbose=False,
                  has_rotor_parameters=False,
                  ref_posture='half_sitting',
@@ -63,7 +63,7 @@ def robot_loader(urdf_filename,
                                        pin.JointModelFreeFlyer() if free_flyer else None)
 
     if srdf_filename is not None:
-        robot.q0 = readParamsFromSrdf(robot.model, join(model_path, srdf_subpath, srdf_filename), verbose,
+        robot.q0 = readParamsFromSrdf(robot.model, join(model_path, path, 'srdf', srdf_filename), verbose,
                                       has_rotor_parameters, ref_posture)
     if free_flyer:
         addFreeFlyerJointLimits(robot.model)
@@ -82,12 +82,11 @@ def loadANYmal(withArm=None):
         REF_POSTURE = "standing_with_arm_up"
 
     URDF_SUBPATH = "anymal_b_simple_description/robots"
-    SRDF_SUBPATH = "anymal_b_simple_description/srdf"
 
-    return robot_loader(URDF_FILENAME,
+    return robot_loader('anymal_b_simple_description',
+                        URDF_FILENAME,
                         URDF_SUBPATH,
                         SRDF_FILENAME,
-                        SRDF_SUBPATH,
                         ref_posture=REF_POSTURE,
                         free_flyer=True)
 
@@ -96,18 +95,16 @@ def loadTalosArm():
     URDF_FILENAME = "talos_left_arm.urdf"
     SRDF_FILENAME = "talos.srdf"
     URDF_SUBPATH = "talos_data/robots"
-    SRDF_SUBPATH = "talos_data/srdf"
 
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH)
+    return robot_loader('talos_data', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME)
 
 
 def loadTalos(legs=False):
     URDF_FILENAME = "talos_reduced.urdf"
     SRDF_FILENAME = "talos.srdf"
-    SRDF_SUBPATH = "talos_data/srdf"
     URDF_SUBPATH = "talos_data/robots"
 
-    robot = robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH, free_flyer=True)
+    robot = robot_loader('talos_data', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, free_flyer=True)
 
     assert (robot.model.armature[:6] == 0.).all()
 
@@ -161,7 +158,7 @@ def loadTalos(legs=False):
         # Load SRDF file
         robot.q0 = robot.q0[:robot.model.nq]
         model_path = getModelPath(join(URDF_SUBPATH, URDF_FILENAME))
-        robot.q0 = readParamsFromSrdf(robot.model, join(model_path, SRDF_SUBPATH, SRDF_FILENAME), False)
+        robot.q0 = readParamsFromSrdf(robot.model, join(model_path, 'talos_data/srdf', SRDF_FILENAME), False)
 
         assert ((m2.armature[:6] == 0.).all())
         # Add the free-flyer joint limits to the new model
@@ -178,13 +175,12 @@ def loadTalosLegs():
 def loadHyQ():
     URDF_FILENAME = "hyq_no_sensors.urdf"
     SRDF_FILENAME = "hyq.srdf"
-    SRDF_SUBPATH = "hyq_description/srdf"
     URDF_SUBPATH = "hyq_description/robots"
 
-    return robot_loader(URDF_FILENAME,
+    return robot_loader('hyq_description',
+                        URDF_FILENAME,
                         URDF_SUBPATH,
                         SRDF_FILENAME,
-                        SRDF_SUBPATH,
                         ref_posture="standing",
                         free_flyer=True)
 
@@ -195,13 +191,12 @@ def loadSolo(solo=True):
     else:
         URDF_FILENAME = "solo12.urdf"
     SRDF_FILENAME = "solo.srdf"
-    SRDF_SUBPATH = "solo_description/srdf"
     URDF_SUBPATH = "solo_description/robots"
 
-    return robot_loader(URDF_FILENAME,
+    return robot_loader('solo_description',
+                        URDF_FILENAME,
                         URDF_SUBPATH,
                         SRDF_FILENAME,
-                        SRDF_SUBPATH,
                         ref_posture="standing",
                         free_flyer=True)
 
@@ -209,26 +204,23 @@ def loadSolo(solo=True):
 def loadKinova():
     URDF_FILENAME = "kinova.urdf"
     SRDF_FILENAME = "kinova.srdf"
-    SRDF_SUBPATH = "kinova_description/srdf"
     URDF_SUBPATH = "kinova_description/robots"
 
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH, ref_posture="arm_up")
+    return robot_loader('kinova_description', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, ref_posture="arm_up")
 
 
 def loadTiago():
     URDF_FILENAME = "tiago.urdf"
     # SRDF_FILENAME = "tiago.srdf"
-    # SRDF_SUBPATH = "tiago_description/srdf"
     URDF_SUBPATH = "tiago_description/robots"
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH)
+    return robot_loader('tiago_description', URDF_FILENAME, URDF_SUBPATH)
 
 
 def loadTiagoNoHand():
     URDF_FILENAME = "tiago_no_hand.urdf"
     # SRDF_FILENAME = "tiago.srdf"
-    # SRDF_SUBPATH = "tiago_description/srdf"
     URDF_SUBPATH = "tiago_description/robots"
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH)
+    return robot_loader('tiago_description', URDF_FILENAME, URDF_SUBPATH)
 
 
 def loadICub(reduced=True):
@@ -237,17 +229,16 @@ def loadICub(reduced=True):
     else:
         URDF_FILENAME = "icub.urdf"
     SRDF_FILENAME = "icub.srdf"
-    SRDF_SUBPATH = "icub_description/srdf"
     URDF_SUBPATH = "icub_description/robots"
 
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH, free_flyer=True)
+    return robot_loader('icub_description', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, free_flyer=True)
 
 
 def loadPanda():
     URDF_FILENAME = "panda.urdf"
     URDF_SUBPATH = "panda_description/urdf"
 
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH)
+    return robot_loader('panda_description', URDF_FILENAME, URDF_SUBPATH)
 
 
 def loadUR(robot=5, limited=False, gripper=False):
@@ -256,37 +247,35 @@ def loadUR(robot=5, limited=False, gripper=False):
     URDF_SUBPATH = "ur_description/urdf"
     if robot == 5 or robot == 3 and gripper:
         SRDF_FILENAME = "ur%i%s.srdf" % (robot, '_gripper' if gripper else '')
-        SRDF_SUBPATH = "ur_description/srdf"
     else:
         SRDF_FILENAME = None
-        SRDF_SUBPATH = None
 
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, SRDF_SUBPATH, ref_posture=None)
+    return robot_loader('ur_description', URDF_FILENAME, URDF_SUBPATH, SRDF_FILENAME, ref_posture=None)
 
 
 def loadHector():
     URDF_FILENAME = "quadrotor_base.urdf"
     URDF_SUBPATH = "hector_description/robots"
 
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
+    return robot_loader('hector_description', URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
 
 
 def loadDoublePendulum():
     URDF_FILENAME = "double_pendulum.urdf"
     URDF_SUBPATH = "double_pendulum_description/urdf"
 
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH)
+    return robot_loader('double_pendulum_description', URDF_FILENAME, URDF_SUBPATH)
 
 
 def loadRomeo():
     URDF_FILENAME = "romeo.urdf"
     URDF_SUBPATH = "romeo_description/urdf"
 
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
+    return robot_loader('romeo_description', URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
 
 
 def loadIris():
     URDF_FILENAME = "iris_simple.urdf"
     URDF_SUBPATH = "iris_description/robots"
 
-    return robot_loader(URDF_FILENAME, URDF_SUBPATH, free_flyer=True)
+    return robot_loader('iris_description', URDF_FILENAME, URDF_SUBPATH, free_flyer=True)

--- a/unittest/test_load.py
+++ b/unittest/test_load.py
@@ -48,13 +48,13 @@ class TalosTest(RobotTestCase):
 
 
 class TalosArmTest(RobotTestCase):
-    RobotTestCase.ROBOT = example_robot_data.loadTalosArm()
+    RobotTestCase.ROBOT = example_robot_data.loadTalos(arm=True)
     RobotTestCase.NQ = 7
     RobotTestCase.NV = 7
 
 
 class TalosArmFloatingTest(RobotTestCase):
-    RobotTestCase.ROBOT = example_robot_data.loadTalosArm()
+    RobotTestCase.ROBOT = example_robot_data.loadTalos(arm=True)
     RobotTestCase.NQ = 14
     RobotTestCase.NV = 13
 

--- a/unittest/test_load.py
+++ b/unittest/test_load.py
@@ -90,7 +90,7 @@ class TiagoTest(RobotTestCase):
 
 
 class TiagoNoHandTest(RobotTestCase):
-    RobotTestCase.ROBOT = example_robot_data.loadTiagoNoHand()
+    RobotTestCase.ROBOT = example_robot_data.loadTiago(hand=False)
     RobotTestCase.NQ = 14
     RobotTestCase.NV = 12
 

--- a/unittest/test_load.py
+++ b/unittest/test_load.py
@@ -60,7 +60,7 @@ class TalosArmFloatingTest(RobotTestCase):
 
 
 class TalosLegsTest(RobotTestCase):
-    RobotTestCase.ROBOT = example_robot_data.loadTalosLegs()
+    RobotTestCase.ROBOT = example_robot_data.loadTalos(legs=True)
     RobotTestCase.NQ = 19
     RobotTestCase.NV = 18
 


### PR DESCRIPTION
To avoid code duplication and ease future robot addition.

While here:
- sync submodule
- use `import pinocchio as pin`
- deprecate `loadTalosLegs()` for the factorized `loadTalos(legs=True)` (and update tests accordingly)
- deprecate `loadTalosArm()` for the factorized `loadTalos(arm=True)` (and update tests accordingly)
- deprecate `loadTalosNoHand()` for the factorized `loadTiago(hand=False)` (and update tests accordingly)
- use cleaner `os.path.join()` for file path manipulation instead of string concatenation
- infer most subpaths ("path / `robots`" in most cases & "path + `srdf`" in all cases)

https://gitlab.laas.fr/gsaurel/example-robot-data/pipelines/10241 (one job is failing because of an on-going CI upgrade)