### PR TITLE
Fix Hyq srdf (disable collision pairs)

### DIFF
--- a/robots/hyq_description/srdf/hyq.srdf
+++ b/robots/hyq_description/srdf/hyq.srdf
@@ -96,8 +96,24 @@
         <joint name="rh_hfe_joint" value="-0.75" />
         <joint name="rh_kfe_joint" value="1.5" />
     </group_state>
-
-    <disable_collisions link1="lf_hipassembly" link2="lf_upperleg" reason="Adjacent" />
+    
+    <disable_collisions link1="lf_hipassembly" link2="trunk" reason="Adjacent"/>
+    <disable_collisions link1="lh_hipassembly" link2="trunk" reason="Adjacent"/>
+    <disable_collisions link1="rf_hipassembly" link2="trunk" reason="Adjacent"/>
+    <disable_collisions link1="rh_hipassembly" link2="trunk" reason="Adjacent"/>
+    <disable_collisions link1="lf_hipassembly" link2="lf_upperleg" reason="Adjacent"/>
+    <disable_collisions link1="lh_hipassembly" link2="lh_upperleg" reason="Adjacent"/>
+    <disable_collisions link1="rf_hipassembly" link2="rf_upperleg" reason="Adjacent"/>
+    <disable_collisions link1="rh_hipassembly" link2="rh_upperleg" reason="Adjacent"/>
+    <disable_collisions link1="lf_lowerleg" link2="lf_upperleg" reason="Adjacent"/>
+    <disable_collisions link1="lh_lowerleg" link2="lh_upperleg" reason="Adjacent"/>
+    <disable_collisions link1="rf_lowerleg" link2="rf_upperleg" reason="Adjacent"/>
+    <disable_collisions link1="rh_lowerleg" link2="rh_upperleg" reason="Adjacent"/>
+    <disable_collisions link1="lf_lowerleg" link2="lf_foot" reason="Adjacent"/>
+    <disable_collisions link1="lh_lowerleg" link2="lh_foot" reason="Adjacent"/>
+    <disable_collisions link1="rf_lowerleg" link2="rf_foot" reason="Adjacent"/>
+    <disable_collisions link1="rh_lowerleg" link2="rh_foot" reason="Adjacent"/>
+    
     <disable_collisions link1="lf_hipassembly" link2="lf_lowerleg" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="rf_hipassembly" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="rf_upperleg" reason="Never" />
@@ -108,5 +124,35 @@
     <disable_collisions link1="lf_hipassembly" link2="rh_hipassembly" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="rh_upperleg" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="rh_lowerleg" reason="Never" />
+    
+    <disable_collisions link1="rf_hipassembly" link2="rf_lowerleg" reason="Never" />
+    <disable_collisions link1="rf_hipassembly" link2="lf_upperleg" reason="Never" />
+    <disable_collisions link1="rf_hipassembly" link2="lf_lowerleg" reason="Never" />
+    <disable_collisions link1="rf_hipassembly" link2="lh_hipassembly" reason="Never" />
+    <disable_collisions link1="rf_hipassembly" link2="lh_upperleg" reason="Never" />
+    <disable_collisions link1="rf_hipassembly" link2="lh_lowerleg" reason="Never" />
+    <disable_collisions link1="rf_hipassembly" link2="rh_hipassembly" reason="Never" />
+    <disable_collisions link1="rf_hipassembly" link2="rh_upperleg" reason="Never" />
+    <disable_collisions link1="rf_hipassembly" link2="rh_lowerleg" reason="Never" />
+    
+    <disable_collisions link1="lh_hipassembly" link2="lh_lowerleg" reason="Never" />
+    <disable_collisions link1="lh_hipassembly" link2="rf_hipassembly" reason="Never" />
+    <disable_collisions link1="lh_hipassembly" link2="rf_upperleg" reason="Never" />
+    <disable_collisions link1="lh_hipassembly" link2="rf_lowerleg" reason="Never" />
+    <disable_collisions link1="lh_hipassembly" link2="lf_upperleg" reason="Never" />
+    <disable_collisions link1="lh_hipassembly" link2="lf_lowerleg" reason="Never" />
+    <disable_collisions link1="lh_hipassembly" link2="rh_hipassembly" reason="Never" />
+    <disable_collisions link1="lh_hipassembly" link2="rh_upperleg" reason="Never" />
+    <disable_collisions link1="lh_hipassembly" link2="rh_lowerleg" reason="Never" />
+    
+    <disable_collisions link1="rh_hipassembly" link2="rh_lowerleg" reason="Never" />
+    <disable_collisions link1="rh_hipassembly" link2="rf_hipassembly" reason="Never" />
+    <disable_collisions link1="rh_hipassembly" link2="rf_upperleg" reason="Never" />
+    <disable_collisions link1="rh_hipassembly" link2="rf_lowerleg" reason="Never" />
+    <disable_collisions link1="rh_hipassembly" link2="lh_hipassembly" reason="Never" />
+    <disable_collisions link1="rh_hipassembly" link2="lh_upperleg" reason="Never" />
+    <disable_collisions link1="rh_hipassembly" link2="lh_lowerleg" reason="Never" />
+    <disable_collisions link1="rh_hipassembly" link2="lf_upperleg" reason="Never" />
+    <disable_collisions link1="rh_hipassembly" link2="lf_lowerleg" reason="Never" />
 
 </robot>

--- a/robots/hyq_description/srdf/hyq.srdf
+++ b/robots/hyq_description/srdf/hyq.srdf
@@ -114,10 +114,8 @@
     <disable_collisions link1="rf_lowerleg" link2="rf_foot" reason="Adjacent"/>
     <disable_collisions link1="rh_lowerleg" link2="rh_foot" reason="Adjacent"/>
     
-    <disable_collisions link1="lf_hipassembly" link2="lf_lowerleg" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="rf_hipassembly" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="rf_upperleg" reason="Never" />
-    <disable_collisions link1="lf_hipassembly" link2="rf_lowerleg" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="lh_hipassembly" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="lh_upperleg" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="lh_lowerleg" reason="Never" />
@@ -125,9 +123,7 @@
     <disable_collisions link1="lf_hipassembly" link2="rh_upperleg" reason="Never" />
     <disable_collisions link1="lf_hipassembly" link2="rh_lowerleg" reason="Never" />
     
-    <disable_collisions link1="rf_hipassembly" link2="rf_lowerleg" reason="Never" />
     <disable_collisions link1="rf_hipassembly" link2="lf_upperleg" reason="Never" />
-    <disable_collisions link1="rf_hipassembly" link2="lf_lowerleg" reason="Never" />
     <disable_collisions link1="rf_hipassembly" link2="lh_hipassembly" reason="Never" />
     <disable_collisions link1="rf_hipassembly" link2="lh_upperleg" reason="Never" />
     <disable_collisions link1="rf_hipassembly" link2="lh_lowerleg" reason="Never" />
@@ -135,7 +131,6 @@
     <disable_collisions link1="rf_hipassembly" link2="rh_upperleg" reason="Never" />
     <disable_collisions link1="rf_hipassembly" link2="rh_lowerleg" reason="Never" />
     
-    <disable_collisions link1="lh_hipassembly" link2="lh_lowerleg" reason="Never" />
     <disable_collisions link1="lh_hipassembly" link2="rf_hipassembly" reason="Never" />
     <disable_collisions link1="lh_hipassembly" link2="rf_upperleg" reason="Never" />
     <disable_collisions link1="lh_hipassembly" link2="rf_lowerleg" reason="Never" />
@@ -143,15 +138,12 @@
     <disable_collisions link1="lh_hipassembly" link2="lf_lowerleg" reason="Never" />
     <disable_collisions link1="lh_hipassembly" link2="rh_hipassembly" reason="Never" />
     <disable_collisions link1="lh_hipassembly" link2="rh_upperleg" reason="Never" />
-    <disable_collisions link1="lh_hipassembly" link2="rh_lowerleg" reason="Never" />
     
-    <disable_collisions link1="rh_hipassembly" link2="rh_lowerleg" reason="Never" />
     <disable_collisions link1="rh_hipassembly" link2="rf_hipassembly" reason="Never" />
     <disable_collisions link1="rh_hipassembly" link2="rf_upperleg" reason="Never" />
     <disable_collisions link1="rh_hipassembly" link2="rf_lowerleg" reason="Never" />
     <disable_collisions link1="rh_hipassembly" link2="lh_hipassembly" reason="Never" />
     <disable_collisions link1="rh_hipassembly" link2="lh_upperleg" reason="Never" />
-    <disable_collisions link1="rh_hipassembly" link2="lh_lowerleg" reason="Never" />
     <disable_collisions link1="rh_hipassembly" link2="lf_upperleg" reason="Never" />
     <disable_collisions link1="rh_hipassembly" link2="lf_lowerleg" reason="Never" />
 


### PR DESCRIPTION
Disable collision pairs for all the adjacents link. 

Add all the "never" colliding collision pairs. For this last point, I did it symmetrically with respect to what was already done for one leg. But I do not really agree with it: a lot of this pairs are never colliding only if we respect the joints limits specified in the URDF. 

I am not sure about what is the policy for this, for me "never" colliding should only be used when it is physically impossible that both links are colliding. 