### PR TITLE
Define unknown materials to hide URDF parser warnings

### DIFF
--- a/robots/hyq_description/robots/hyq_no_sensors.urdf
+++ b/robots/hyq_description/robots/hyq_no_sensors.urdf
@@ -4,6 +4,12 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <robot name="hyq" xmlns:xacro="http://ros.org/wiki/xacro">
+  <material name="white">
+    <color rgba="1 1 1 1"/>
+  </material>
+  <material name="black">
+    <color rgba="0 0 0 1"/>
+  </material>
   <!-- This argument allows us to load joint sensors that measure the internal wrenches -->
   <!-- The following included files set up definitions of parts of the robot body -->
   <!-- kin limits (sign ref is RH leg)-->

--- a/robots/talos_data/robots/talos_full_v2.urdf
+++ b/robots/talos_data/robots/talos_full_v2.urdf
@@ -13,6 +13,9 @@
   Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
 -->
 <robot name="talos" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+  <material name="FlatBlack">
+    <color rgba="0.1 0.1 0.1 1"/>
+  </material>
   <!--************************-->
   <!--        TORSO_2  (TILT) -->
   <!--************************-->

--- a/robots/talos_data/robots/talos_full_v2_box.urdf
+++ b/robots/talos_data/robots/talos_full_v2_box.urdf
@@ -13,6 +13,9 @@
   Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
 -->
 <robot name="talos" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+  <material name="FlatBlack">
+    <color rgba="0.1 0.1 0.1 1"/>
+  </material>
   <!--************************-->
   <!--        TORSO_2  (TILT) -->
   <!--************************-->

--- a/robots/talos_data/robots/talos_left_arm.urdf
+++ b/robots/talos_data/robots/talos_left_arm.urdf
@@ -13,8 +13,9 @@
   Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
 -->
 <robot name="talos" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://ros.org/wiki/xacro">
-
-
+  <material name="FlatBlack">
+    <color rgba="0.1 0.1 0.1 1"/>
+  </material>
   <link name="arm_left_1_link">
     <!-- TODO: Missing reflects of inertias -->
     <inertial>

--- a/robots/talos_data/robots/talos_reduced.urdf
+++ b/robots/talos_data/robots/talos_reduced.urdf
@@ -13,6 +13,9 @@
   Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
 -->
 <robot name="talos" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+  <material name="FlatBlack">
+    <color rgba="0.1 0.1 0.1 1"/>
+  </material>
   <!--File includes-->
   <!--Constant parameters-->
   <!--File includes-->

--- a/robots/talos_data/robots/talos_reduced_box.urdf
+++ b/robots/talos_data/robots/talos_reduced_box.urdf
@@ -13,6 +13,9 @@
   Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
 -->
 <robot name="talos" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://ros.org/wiki/xacro">
+  <material name="FlatBlack">
+    <color rgba="0.1 0.1 0.1 1"/>
+  </material>
   <!--File includes-->
   <!--Constant parameters-->
   <!--File includes-->

--- a/robots/tiago_description/robots/tiago.urdf
+++ b/robots/tiago_description/robots/tiago.urdf
@@ -15,6 +15,9 @@
   <material name="Hey5DarkGrey">
     <color rgba="0.1 0.1 0.1 1.0"/>
   </material>
+  <material name="FlatBlack">
+    <color rgba="0.1 0.1 0.1 1"/>
+  </material>
   <!--TODO: Check-->
   <gazebo>
     <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_control">

--- a/robots/tiago_description/robots/tiago_no_hand.urdf
+++ b/robots/tiago_description/robots/tiago_no_hand.urdf
@@ -15,6 +15,9 @@
   <material name="Hey5DarkGrey">
     <color rgba="0.1 0.1 0.1 1.0"/>
   </material>
+  <material name="FlatBlack">
+    <color rgba="0.1 0.1 0.1 1"/>
+  </material>
   <!--TODO: Check-->
   <gazebo>
     <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_control">


### PR DESCRIPTION
While debugging Crocoddyl unit tests, we often see a ton of warnings about materials that can't be found which makes it hard to identify the error messages. Defining the missing materials silences all warnings and we can focus on the error messages without scrolling :sunglasses: 