### PR TITLE
Removing duplication of q0 in RobotLoader, instead using the one introduced in RobotWrapper

### DIFF
--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -66,8 +66,8 @@ class RobotLoader(object):
 
         if self.srdf_filename:
             self.srdf_path = join(self.model_path, self.path, self.srdf_subpath, self.srdf_filename)
-            self.robot.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose, self.has_rotor_parameters,
-                                         self.ref_posture)
+            self.robot.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose,
+                                               self.has_rotor_parameters, self.ref_posture)
         else:
             self.srdf_path = None
             self.robot.q0 = None
@@ -182,8 +182,8 @@ class TalosLegsLoader(TalosLoader):
         self.robot.visual_data = pin.GeometryData(g2)
 
         # Load SRDF file
-        self.robot.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose, self.has_rotor_parameters,
-                                     self.ref_posture)
+        self.robot.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose,
+                                           self.has_rotor_parameters, self.ref_posture)
 
         assert (m2.armature[:6] == 0.).all()
         # Add the free-flyer joint limits to the new model

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -66,11 +66,11 @@ class RobotLoader(object):
 
         if self.srdf_filename:
             self.srdf_path = join(self.model_path, self.path, self.srdf_subpath, self.srdf_filename)
-            self.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose, self.has_rotor_parameters,
+            self.robot.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose, self.has_rotor_parameters,
                                          self.ref_posture)
         else:
             self.srdf_path = None
-            self.q0 = None
+            self.robot.q0 = None
 
         if self.free_flyer:
             self.addFreeFlyerJointLimits()
@@ -182,7 +182,7 @@ class TalosLegsLoader(TalosLoader):
         self.robot.visual_data = pin.GeometryData(g2)
 
         # Load SRDF file
-        self.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose, self.has_rotor_parameters,
+        self.robot.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose, self.has_rotor_parameters,
                                      self.ref_posture)
 
         assert (m2.armature[:6] == 0.).all()
@@ -509,4 +509,4 @@ def load(name, display=False, rootNodeName=''):
 def load_full(name, display=False, rootNodeName=''):
     """Load a robot by its name, optionnaly display it in a viewer, and provide its q0 and paths."""
     inst = loader(name, display, rootNodeName)
-    return inst.robot, inst.q0, inst.urdf_path, inst.srdf_path
+    return inst.robot, inst.robot.q0, inst.urdf_path, inst.srdf_path

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -83,6 +83,11 @@ class RobotLoader(object):
         lb[:7] = -1
         self.robot.model.lowerPositionLimit = lb
 
+    @property
+    def q0(self):
+        warnings.warn("`q0` is deprecated. Please use `robot.q0`", FutureWarning, 2)
+        return self.robot.q0
+
 
 class ANYmalLoader(RobotLoader):
     path = 'anymal_b_simple_description'


### PR DESCRIPTION
The `q0` duplication confused me, as I was not sure why the `RobotWrapper.q0` was not filled during calling `load` or `load_full` functions.
