### PR TITLE
Define q0 as neutral if the robot doesn't have a SRDF

### DIFF
--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -70,7 +70,7 @@ class RobotLoader(object):
                                                self.has_rotor_parameters, self.ref_posture)
         else:
             self.srdf_path = None
-            self.robot.q0 = None
+            self.robot.q0 = pin.neutral(self.robot.model)
 
         if self.free_flyer:
             self.addFreeFlyerJointLimits()


### PR DESCRIPTION
Without this rule, I triggered an error in some hector-based examples defined in Crocoddyl.