### PR TITLE
 Define q0 as neutral if the robot doesn't have a SRDF

### DIFF
--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -66,8 +66,8 @@ class RobotLoader(object):
 
         if self.srdf_filename:
             self.srdf_path = join(self.model_path, self.path, self.srdf_subpath, self.srdf_filename)
-            self.robot.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose,
-                                               self.has_rotor_parameters, self.ref_posture)
+            self.robot.q0 = readParamsFromSrdf(self.robot.model, self.srdf_path, self.verbose, self.has_rotor_parameters,
+                                               self.ref_posture)
         else:
             self.srdf_path = None
             self.robot.q0 = pin.neutral(self.robot.model)

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -70,7 +70,7 @@ class RobotLoader(object):
                                                self.has_rotor_parameters, self.ref_posture)
         else:
             self.srdf_path = None
-            self.robot.q0 = None
+            self.robot.q0 = pin.neutral(self.robot.model)
 
         if self.free_flyer:
             self.addFreeFlyerJointLimits()


### PR DESCRIPTION
Without this rule, I triggered an error in some hector-based examples defined in Crocoddyl.

Note
I have (by mistake) pushed #79 changes into the devel branch.
Then, I forced the push to return the devel branch to its original state.
However, this triggered a `merged` tag by github, despite that this is not true now.