### PR TITLE
robots: document upstreams & license, fix #34

### DIFF
--- a/robots/anymal_b_simple_description/README.md
+++ b/robots/anymal_b_simple_description/README.md
@@ -1,0 +1,4 @@
+# ANYmal B Robot Description
+
+upstream: https://github.com/ANYbotics/anymal_b_simple_description
+license: BSD-3-Clause

--- a/robots/baxter_description/README.md
+++ b/robots/baxter_description/README.md
@@ -1,0 +1,4 @@
+# Baxter Description
+
+upstream: https://github.com/RethinkRobotics/baxter_common/tree/master/baxter_description
+license: BSD

--- a/robots/bolt_description/README.md
+++ b/robots/bolt_description/README.md
@@ -1,0 +1,4 @@
+# Robot Properties Bolt
+
+upstream: https://github.com/open-dynamic-robot-initiative/robot_properties_bolt/tree/master/src/robot_properties_bolt/robot_properties_bolt
+license: BSD-3-Clause

--- a/robots/double_pendulum_description/README.md
+++ b/robots/double_pendulum_description/README.md
@@ -1,0 +1,4 @@
+# Double Pendulum
+
+upstream: None. Original work from [@PepMS](https://github.com/PepMS).
+license: BSD

--- a/robots/finger_edu_description/README.md
+++ b/robots/finger_edu_description/README.md
@@ -1,0 +1,4 @@
+# FingerEdu v1
+
+upstream: https://github.com/open-dynamic-robot-initiative/open_robot_actuator_hardware/blob/master/mechanics/finger_edu_v1
+license: BSD-3-Clause

--- a/robots/hector_description/README.md
+++ b/robots/hector_description/README.md
@@ -1,0 +1,4 @@
+# Hector Models
+
+upstream: https://github.com/tu-darmstadt-ros-pkg/hector_models
+license: BSD

--- a/robots/hyq_description/README.md
+++ b/robots/hyq_description/README.md
@@ -1,0 +1,4 @@
+# HyQ Description
+
+upstream: https://github.com/iit-DLSLab/hyq-description
+license: Apache License 2.0

--- a/robots/icub_description/README.md
+++ b/robots/icub_description/README.md
@@ -1,0 +1,4 @@
+# iCub models
+
+upstream: https://github.com/robotology/icub-models/tree/master/iCub
+license: CC-BY-SA-4.0

--- a/robots/iris_description/README.md
+++ b/robots/iris_description/README.md
@@ -1,0 +1,4 @@
+# Rotors Simulator
+
+upstream: https://github.com/ethz-asl/rotors_simulator/tree/master/rotors_description
+License: ASL 2.0

--- a/robots/kinova_description/README.md
+++ b/robots/kinova_description/README.md
@@ -1,0 +1,4 @@
+# Kinova ROS
+
+upstream: https://github.com/Kinovarobotics/kinova-ros/tree/melodic-devel/kinova_description
+license: BSD

--- a/robots/panda_description/README.md
+++ b/robots/panda_description/README.md
@@ -1,0 +1,4 @@
+# Panda ign
+
+upstream: https://github.com/frankaemika/franka_ros/tree/noetic-devel/franka_description
+license: Apache 2.0

--- a/robots/romeo_description/README.md
+++ b/robots/romeo_description/README.md
@@ -1,0 +1,4 @@
+# Romeo Description
+
+upstream: https://github.com/laas/romeo/tree/master/romeo_description
+license: BSD

--- a/robots/simple_humanoid_description/README.md
+++ b/robots/simple_humanoid_description/README.md
@@ -1,0 +1,4 @@
+# Simple Humanoid Description
+
+upstream: https://github.com/laas/simple_humanoid_description
+license: BSD-2-Clause

--- a/robots/solo_description/README.md
+++ b/robots/solo_description/README.md
@@ -1,0 +1,4 @@
+# Robot Properties Solo
+
+upstream: https://github.com/open-dynamic-robot-initiative/robot_properties_solo/tree/master/src/robot_properties_solo/robot_properties_solo
+license: BSD-3-Clause

--- a/robots/talos_data/README.md
+++ b/robots/talos_data/README.md
@@ -1,0 +1,4 @@
+# Talos Data
+
+upstream: https://github.com/stack-of-tasks/talos-data
+license: LGPL-3.0

--- a/robots/tiago_description/README.md
+++ b/robots/tiago_description/README.md
@@ -1,0 +1,4 @@
+# Tiago Description
+
+upstream: https://github.com/pal-robotics/tiago_robot/tree/kinetic-devel/tiago_description
+license: CC-BY-NC-ND 3.0

--- a/robots/ur_description/README.md
+++ b/robots/ur_description/README.md
@@ -1,0 +1,4 @@
+# UR Description
+
+upstream: https://github.com/ros-industrial/universal_robot/tree/kinetic-devel/ur_description
+license: BSD


### PR DESCRIPTION
Hello,

This PR only documents individual robots origin and license.

This raise a few issues:
- the compatibily between LGPL (Talos) / CC-BY-SA-4.0 (iCub) with this BSD project are not clear
- CC-BY-NC-ND 3.0 (Tiago) clearly forbids us to distribute it here
- I was not able to find anything about double-pendulum. @PepMS : is this an original work for this project (in that case, it just has a BSD license), or did you adapt that from somewhere else ?

Other works in BSD / Apache are OK