### PR TITLE
Wrong rotation in allegro visual urdf description

### DIFF
--- a/robots/allegro_hand_description/urdf/allegro_right_hand.urdf
+++ b/robots/allegro_hand_description/urdf/allegro_right_hand.urdf
@@ -463,7 +463,7 @@
       <material name="black">
         <color rgba=".2 .2 .2 1"/>
       </material>
-      <origin rpy="3.1415926518 0 0" xyz="0 0 0"/>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
     </visual>
     <collision>
       <geometry>


### PR DESCRIPTION
An incorrect rotation in the material of link 12 was causing the hand to look like:
<img width="848" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/27144054/218125408-adf154a7-54c4-47fe-8207-c38d86e59b1e.png">

Now it looks like:
<img width="875" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/27144054/218125466-cdc509af-d49e-4e88-a8af-7ec60f5d93a6.png">
