### PR TITLE
always try to import MODEL_DIR and DATA_SOURCE_DIR

### DIFF
--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -5,6 +5,10 @@ import numpy as np
 import pinocchio as pin
 from pinocchio.robot_wrapper import RobotWrapper
 
+try:
+    from .path import EXAMPLE_ROBOT_DATA_MODEL_DIR, EXAMPLE_ROBOT_DATA_SOURCE_DIR
+except ImportError:
+    pass
 
 def getModelPath(subpath, printmsg=False):
     source = dirname(dirname(dirname(__file__)))  # top level source directory
@@ -17,13 +21,13 @@ def getModelPath(subpath, printmsg=False):
         join(source, "robots"),
     ]
     try:
-        from .path import EXAMPLE_ROBOT_DATA_MODEL_DIR, EXAMPLE_ROBOT_DATA_SOURCE_DIR
+        EXAMPLE_ROBOT_DATA_MODEL_DIR
 
         # function called from installed project
         paths.append(EXAMPLE_ROBOT_DATA_MODEL_DIR)
         # function called from off-tree build dir
         paths.append(EXAMPLE_ROBOT_DATA_SOURCE_DIR)
-    except ImportError:
+    except NameError:
         pass
     paths += [join(p, "../../../share/example-robot-data/robots") for p in sys.path]
     for path in paths:

--- a/python/example_robot_data/robots_loader.py
+++ b/python/example_robot_data/robots_loader.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     pass
 
+
 def getModelPath(subpath, printmsg=False):
     source = dirname(dirname(dirname(__file__)))  # top level source directory
     paths = [


### PR DESCRIPTION
Hello, I'm currently using `example-robot-data` to have access to different urdf files. But in my case, I do not want to use the `RobotLoader`, but use `pinocchio` to build my model from URDF directly. I noticed, that you can do
```
import example_robot_data as erd
erd.getModelPath()  # of course this fails
erd.path.EXAMPLE_ROBOT_DATA_MODEL_DI
```
but you cannot directly access `erd.path` after loading the python module. I think it can be useful in general to have access to both `EXAMPLE_ROBOT_DATA_MODEL_DIR` and `EXAMPLE_ROBOT_DATA_SOURCE_DIR` even without calling a specific function before.