### PR TITLE
Supported pinocchio with cppadcg installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ project(${PROJECT_NAME} ${PROJECT_ARGS})
 if(BUILD_PYTHON_INTERFACE)
   add_project_dependency(eigenpy 2.7.11 REQUIRED)
   include("${JRL_CMAKE_MODULES}/python.cmake")
+  set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/find-external/CppAD/"
+                       ${CMAKE_MODULE_PATH})
   add_project_dependency(pinocchio REQUIRED)
   string(REGEX REPLACE "-" "_" PY_NAME ${PROJECT_NAME})
   add_subdirectory(python)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if(BUILD_PYTHON_INTERFACE)
   add_project_dependency(eigenpy 2.7.11 REQUIRED)
   include("${JRL_CMAKE_MODULES}/python.cmake")
   set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/find-external/CppAD/"
-                       ${CMAKE_MODULE_PATH})
+                        ${CMAKE_MODULE_PATH})
   add_project_dependency(pinocchio REQUIRED)
   string(REGEX REPLACE "-" "_" PY_NAME ${PROJECT_NAME})
   add_subdirectory(python)


### PR DESCRIPTION
This enables us to install example-robot-data when Pinocchio has been installed with CppADCogen