### PR TITLE
CMake: require >= 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 # Project properties
 set(PROJECT_ORG gepetto)


### PR DESCRIPTION
ref. https://github.com/jrl-umi3218/jrl-cmakemodules/issues/338 and fix deprecation warning about CMake 3.5 from CMake 3.27