### PR TITLE
Fix wrong position of the center of mass for Solo-8 and Solo-12 lower legs

### DIFF
--- a/robots/solo_description/robots/solo.urdf
+++ b/robots/solo_description/robots/solo.urdf
@@ -234,7 +234,7 @@
   <link name="FR_LOWER_LEG">
     <!-- Right lower leg inertia -->
     <inertial>
-      <origin rpy="0 0 0" xyz="0.0 0.00787644 -0.08928215"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.00787644 -0.08928215"/>
       <mass value="0.03070001"/>
       <inertia ixx="0.00012024" ixy="0.0" ixz="0.0" iyy="0.00012029" iyz="-0.00000305" izz="0.00000216"/>
     </inertial>
@@ -504,7 +504,7 @@
   <link name="HR_LOWER_LEG">
     <!-- Right lower leg inertia -->
     <inertial>
-      <origin rpy="0 0 0" xyz="0.0 0.00787644 -0.08928215"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.00787644 -0.08928215"/>
       <mass value="0.03070001"/>
       <inertia ixx="0.00012024" ixy="0.0" ixz="0.0" iyy="0.00012029" iyz="-0.00000305" izz="0.00000216"/>
     </inertial>

--- a/robots/solo_description/robots/solo12.urdf
+++ b/robots/solo_description/robots/solo12.urdf
@@ -312,7 +312,7 @@
   <link name="FR_LOWER_LEG">
     <!-- Right lower leg inertia -->
     <inertial>
-      <origin rpy="0 0 0" xyz="0.0 0.00787644 -0.08928215"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.00787644 -0.08928215"/>
       <mass value="0.03070001"/>
       <inertia ixx="0.00012024" ixy="0.0" ixz="0.0" iyy="0.00012029" iyz="-0.00000305" izz="0.00000216"/>
     </inertial>
@@ -660,7 +660,7 @@
   <link name="HR_LOWER_LEG">
     <!-- Right lower leg inertia -->
     <inertial>
-      <origin rpy="0 0 0" xyz="0.0 0.00787644 -0.08928215"/>
+      <origin rpy="0 0 0" xyz="0.0 -0.00787644 -0.08928215"/>
       <mass value="0.03070001"/>
       <inertia ixx="0.00012024" ixy="0.0" ixz="0.0" iyy="0.00012029" iyz="-0.00000305" izz="0.00000216"/>
     </inertial>


### PR DESCRIPTION
This PR fixes a small mistake in the position of the center of mass for the lower leg inertia, causing the center of mass to be slightly sideways although the robot should be symmetric.

Using:
```
# Compute CoM position
q0 = pin.neutral(model)
pin.centerOfMass(model, data, q0)
print(data.com[0])
```
returns `[ 0.          0.00038689 -0.03449762]` before the fix, and `[ 0.          0.         -0.03449762]` after.