### PR TITLE
Fix ROS2 installation

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,6 @@
+{
+    "hooks": [
+        "share/example-robot-data/hook/ament_prefix_path.dsv",
+        "share/example-robot-data/hook/python_path.dsv"
+    ]
+}


### PR DESCRIPTION
Hello,

Currently, when working with ros2 (ament /colcon), users usually need to set environment variables by hand in order for some tools (such has RViz 2) to find **example-robot-data** packages. (for instance, the `AMENT_PREFIX_PATH` variable)

Thanks to @olivier-stasse PR, https://github.com/jrl-umi3218/jrl-cmakemodules/pull/717, the **jrl-cmakemodules** can create the necessary files during installation so that when the user `source install/setup.bash` the env variable are set.

So in this PR I propose to update the **jrl-cmakemodules** submodule (and add the small colcon.pkg file)