### PR TITLE
Fix collision model for Panda

### DIFF
--- a/robots/panda_description/urdf/panda_collision.urdf
+++ b/robots/panda_description/urdf/panda_collision.urdf
@@ -311,21 +311,21 @@
             </geometry>
         </collision>
         <collision>
-            <origin rpy="0 1.5707963267948966 0" xyz="0.06 0 0.082"/>
+            <origin rpy="1.57 0 -0.785" xyz="0.04 0.04 0.09"/>
             <geometry>
-                <cylinder length="0.01" radius="0.06"/>
+                <cylinder length="0.01" radius="0.045"/>
             </geometry>
         </collision>
         <collision>
-            <origin xyz="0.065 0 0.082"/>
+            <origin xyz="0.043535534 0.043535534 0.09"/>
             <geometry>
-                <sphere radius="0.06"/>
+                <sphere radius="0.045"/>
             </geometry>
         </collision>
         <collision>
-            <origin xyz="0.055 0 0.082"/>
+            <origin xyz="0.036464466 0.036464466 0.09"/>
             <geometry>
-                <sphere radius="0.06"/>
+                <sphere radius="0.045"/>
         </geometry>
         </collision>
         <inertial>
@@ -369,7 +369,19 @@
         <collision>
             <origin rpy="1.57 0 0" xyz="0 0 3e-2"/>
             <geometry>
-                <cylinder length="0.25" radius="0.04"/>
+                <cylinder length="0.15" radius="0.05"/>
+            </geometry>
+        </collision>
+        <collision>
+            <origin xyz="0 -0.075 3e-2"/>
+            <geometry>
+                <sphere radius="0.05"/>
+            </geometry>
+        </collision>
+        <collision>
+            <origin xyz="0 0.075 3e-2"/>
+            <geometry>
+                <sphere radius="0.05"/>
             </geometry>
         </collision>
         <inertial>
@@ -401,7 +413,19 @@
         <collision>
             <origin rpy="0 0 0" xyz="0 15e-3 3e-2"/>
             <geometry>
-                <cylinder length="0.07" radius="0.015"/>
+                <cylinder length="0.03" radius="0.015"/>
+            </geometry>
+        </collision>
+        <collision>
+            <origin xyz="0 15e-3 15e-3"/>
+            <geometry>
+                <sphere radius="0.015"/>
+            </geometry>
+        </collision>
+        <collision>
+            <origin xyz="0 15e-3 45e-3"/>
+            <geometry>
+                <sphere radius="0.015"/>
             </geometry>
         </collision>
         <inertial>
@@ -418,10 +442,22 @@
             </geometry>
         </visual>
         <!-- screw mount -->
-        <collision>
+         <collision>
             <origin rpy="0 0 0" xyz="0 -15e-3 3e-2"/>
             <geometry>
-                <cylinder length="0.07" radius="0.015"/>
+                <cylinder length="0.03" radius="0.015"/>
+            </geometry>
+        </collision>
+        <collision>
+            <origin xyz="0 -15e-3 15e-3"/>
+            <geometry>
+                <sphere radius="0.015"/>
+            </geometry>
+        </collision>
+        <collision>
+            <origin xyz="0 -15e-3 45e-3"/>
+            <geometry>
+                <sphere radius="0.015"/>
             </geometry>
         </collision>
         <inertial>


### PR DESCRIPTION
This PR fixes bugs accidentally introduced in https://github.com/Gepetto/example-robot-data/pull/242.

Turns out the capsule for the guidance buttons was rotated by 45 degrees and of a wrong size. Additionally, capsules representing hand and fingertips were missing spheres, leaving it as only cylinders and not "full capsules".

Differences can be seen in the images below.

Before             |  Fixed
:-------------------------:|:-------------------------:
![Screenshot from 2025-01-14 16-37-42](https://github.com/user-attachments/assets/d47f8b50-89d7-45da-807c-f42a023abc4e) | ![Screenshot from 2025-01-14 16-37-35](https://github.com/user-attachments/assets/e8c42c83-7ecd-4224-8166-bc6dfda6597a)
![Screenshot from 2025-01-14 16-38-25](https://github.com/user-attachments/assets/edc6ab39-0561-4277-913b-5ba5d36633d2) | ![Screenshot from 2025-01-14 16-38-18](https://github.com/user-attachments/assets/aca3aa70-7a2b-45f6-a8e8-2b53da99b7b5) 
![Screenshot from 2025-01-14 16-39-18](https://github.com/user-attachments/assets/6ce9bc6c-1d8d-49b6-a202-285e60f1d012) | ![Screenshot from 2025-01-14 16-39-10](https://github.com/user-attachments/assets/35fa9a85-2c2f-4114-803c-093d69a59173)
