### PR TITLE
Specify submodule branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "cmake"]
+	branch = master
 	path = cmake
 	url = https://github.com/jrl-umi3218/jrl-cmakemodules.git


### PR DESCRIPTION
Works around <https://github.com/NixOS/nix/issues/10773>, allowing Nix evaluations to complete with one fewer round-trips.