### PR TITLE
ur_description: remove all "LightGrey" `<material>` tags from URDF files

### DIFF
--- a/robots/ur_description/urdf/ur10_joint_limited_robot.urdf
+++ b/robots/ur_description/urdf/ur10_joint_limited_robot.urdf
@@ -34,9 +34,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/base.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -62,9 +59,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/shoulder.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -90,9 +84,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/upperarm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -118,9 +109,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/forearm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -146,9 +134,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/wrist1.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -174,9 +159,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/wrist2.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -202,9 +184,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/wrist3.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>

--- a/robots/ur_description/urdf/ur10_robot.urdf
+++ b/robots/ur_description/urdf/ur10_robot.urdf
@@ -34,9 +34,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/base.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -62,9 +59,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/shoulder.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -90,9 +84,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/upperarm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -118,9 +109,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/forearm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -146,9 +134,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/wrist1.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -174,9 +159,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/wrist2.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -202,9 +184,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur10/visual/wrist3.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>

--- a/robots/ur_description/urdf/ur3_gripper.urdf
+++ b/robots/ur_description/urdf/ur3_gripper.urdf
@@ -47,9 +47,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/base.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -75,9 +72,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/shoulder.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -103,9 +97,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/upperarm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -131,9 +122,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/forearm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -159,9 +147,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/wrist1.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -187,9 +172,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/wrist2.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -215,9 +197,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/wrist3.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -332,27 +311,18 @@
 	<box size="0.005 0.02 0.05" />
       </geometry>
       <origin xyz="0.03 0 0.035" />
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <visual>
       <geometry>
 	<box size="0.005 0.02 0.05" />
       </geometry>
       <origin xyz="-0.03 0 0.035" />
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <visual>
       <geometry>
 	<box size="0.065 0.02 0.005" />
       </geometry>
       <origin xyz="0 0 0.01" />
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
 
     <collision>

--- a/robots/ur_description/urdf/ur3_joint_limited_robot.urdf
+++ b/robots/ur_description/urdf/ur3_joint_limited_robot.urdf
@@ -33,9 +33,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/base.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -61,9 +58,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/shoulder.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -89,9 +83,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/upperarm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -117,9 +108,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/forearm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -145,9 +133,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/wrist1.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -173,9 +158,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/wrist2.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -201,9 +183,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/wrist3.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>

--- a/robots/ur_description/urdf/ur3_robot.urdf
+++ b/robots/ur_description/urdf/ur3_robot.urdf
@@ -33,9 +33,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/base.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -61,9 +58,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/shoulder.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -89,9 +83,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/upperarm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -117,9 +108,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/forearm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -145,9 +133,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/wrist1.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -173,9 +158,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/wrist2.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -201,9 +183,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur3/visual/wrist3.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>

--- a/robots/ur_description/urdf/ur5_gripper.urdf
+++ b/robots/ur_description/urdf/ur5_gripper.urdf
@@ -67,9 +67,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/base.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -95,9 +92,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/shoulder.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -123,9 +117,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/upperarm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -151,9 +142,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/forearm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -179,9 +167,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/wrist1.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -207,9 +192,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/wrist2.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -235,9 +217,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/wrist3.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -352,27 +331,18 @@
 	<box size="0.005 0.02 0.05" />
       </geometry>
       <origin xyz="0.03 0 0.035" />
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <visual>
       <geometry>
 	<box size="0.005 0.02 0.05" />
       </geometry>
       <origin xyz="-0.03 0 0.035" />
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <visual>
       <geometry>
 	<box size="0.065 0.02 0.005" />
       </geometry>
       <origin xyz="0 0 0.01" />
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
 
     <collision>

--- a/robots/ur_description/urdf/ur5_joint_limited_robot.urdf
+++ b/robots/ur_description/urdf/ur5_joint_limited_robot.urdf
@@ -43,9 +43,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/base.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -71,9 +68,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/shoulder.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -99,9 +93,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/upperarm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -127,9 +118,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/forearm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -155,9 +143,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/wrist1.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -183,9 +168,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/wrist2.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -211,9 +193,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/wrist3.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>

--- a/robots/ur_description/urdf/ur5_robot.urdf
+++ b/robots/ur_description/urdf/ur5_robot.urdf
@@ -43,9 +43,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/base.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -71,9 +68,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/shoulder.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -99,9 +93,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/upperarm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -127,9 +118,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/forearm.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -155,9 +143,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/wrist1.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -183,9 +168,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/wrist2.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>
@@ -211,9 +193,6 @@
       <geometry>
         <mesh filename="package://example-robot-data/robots/ur_description/meshes/ur5/visual/wrist3.dae"/>
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0"/>
-      </material>
     </visual>
     <collision>
       <geometry>


### PR DESCRIPTION
This triggered Pinocchio's URDF parser to set `geometry_object.overrideMaterial` to `true` on all loaded `GeometryObject`s, although the loaded meshes have perfectly serviceable materials.

cc @nim65s 